### PR TITLE
Add media copying back to csv product writer

### DIFF
--- a/Writer/File/CsvProductWriter.php
+++ b/Writer/File/CsvProductWriter.php
@@ -17,6 +17,18 @@ class CsvProductWriter extends BaseCsvProductWriter
             $products[] = $item['product'];
         }
         CsvWriter::write($products);
+        
+        $exportDirectory = dirname($this->getPath());
+        if (!is_dir($exportDirectory)) {
+            $this->localFs->mkdir($exportDirectory);
+        }
+        foreach ($items as $item) {
+            foreach ($item['media'] as $media) {
+                if ($media && isset($media['filePath']) && $media['filePath']) {
+                    $this->copyMedia($media);
+                }
+            }
+        }
     }
 
     public function getConfigurationFields()


### PR DESCRIPTION
Images need to be copied to a mounted directory during export for them to be visible to Magento.