### PR TITLE
Defaults for media config

### DIFF
--- a/MediaExport/ExportLocation.php
+++ b/MediaExport/ExportLocation.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Snowio\Bundle\MediaExport;
+
+class ExportLocation
+{
+    /** @var  string */
+    private $directory;
+
+    /** @var string|null */
+    private $host;
+
+    /** @var string|null */
+    private $user;
+
+    public function __construct($directory, $host = null, $user = null)
+    {
+        $this->directory = $directory;
+        $this->host = $host;
+        $this->user = $user;
+    }
+
+    /**
+     * @return string
+     */
+    public function toString()
+    {
+        if ($this->user && $this->host) {
+            return sprintf(
+                '%s@%s:%s',
+                $this->user,
+                $this->host,
+                $this->directory
+            );
+        }
+
+        if (!$this->user && $this->host) {
+            return sprintf(
+                '%s:%s',
+                $this->host,
+                $this->directory
+            );
+        }
+
+        return $this->directory;
+    }
+}

--- a/MediaExport/ExportLocation.php
+++ b/MediaExport/ExportLocation.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace Snowio\Bundle\MediaExport;
+namespace Snowio\Bundle\CsvConnectorBundle\MediaExport;
 
 class ExportLocation
 {
     /** @var  string */
     private $directory;
 
-    /** @var string|null */
+    /** @var string|false */
     private $host;
 
-    /** @var string|null */
+    /** @var string|false */
     private $user;
 
-    public function __construct($directory, $host = null, $user = null)
+    public function __construct($directory, $host = false, $user = false)
     {
         $this->directory = $directory;
         $this->host = $host;

--- a/Resources/config/steps.yml
+++ b/Resources/config/steps.yml
@@ -6,6 +6,7 @@ parameters:
     snowio_connector.step.archive.zip.class: ZipArchive
     snowio_connector.step.media_export.class: Snowio\Bundle\CsvConnectorBundle\Step\MediaExportStep
     snowio_connector.step.check_thresholds.class: Snowio\Bundle\CsvConnectorBundle\Step\CheckThresholdsStep
+    snowio_connector.media_export.export_location.class: Snowio\Bundle\CsvConnectorBundle\MediaExport\ExportLocation
 
 services:
     guzzlehttp.client:
@@ -22,7 +23,7 @@ services:
             - '@akeneo_batch.job_repository'
             - '@snowio_connector.step.archive.zip'
 
-    snowio_connecor.media_export.export_location:
+    snowio_connector.media_export.export_location:
         class: '%snowio_connector.media_export.export_location.class%'
         arguments:
             - '%media_export_directory%'

--- a/Resources/config/steps.yml
+++ b/Resources/config/steps.yml
@@ -22,13 +22,20 @@ services:
             - '@akeneo_batch.job_repository'
             - '@snowio_connector.step.archive.zip'
 
+    snowio_connecor.media_export.export_location:
+        class: '%snowio_connector.media_export.export_location.class%'
+        arguments:
+            - '%media_export_directory%'
+            - '%media_export_host%'
+            - '%media_export_user%'
+
     snowio_connector.step.media_export:
         class: '%snowio_connector.step.media_export.class%'
         arguments:
             - 'media_export'
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
-            - '%media_export_user%@%media_export_host%:%media_export_directory%'
+            - '@snowio_connector.media_export.export_location'
             - '%kernel.root_dir%/logs/%media_export_log_filename%'
 
     snowio_connector.step.post:

--- a/Step/CheckThresholdsStep.php
+++ b/Step/CheckThresholdsStep.php
@@ -27,7 +27,7 @@ class CheckThresholdsStep extends AbstractStep
         $name,
         EventDispatcherInterface $eventDispatcher,
         JobRepositoryInterface $jobRepository,
-        $minimumExportThreshold
+        $minimumExportThreshold = 0
     ) {
         parent::__construct($name, $eventDispatcher, $jobRepository);
         $this->minimumExportThreshold = (int)$minimumExportThreshold;

--- a/Step/MediaExportStep.php
+++ b/Step/MediaExportStep.php
@@ -6,7 +6,7 @@ use Akeneo\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\AbstractStep;
 use Akeneo\Component\FileStorage\Exception\FileTransferException;
-use Snowio\Bundle\MediaExport\ExportLocation;
+use Snowio\Bundle\CsvConnectorBundle\MediaExport\ExportLocation;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 
@@ -17,7 +17,7 @@ use Symfony\Component\Filesystem\Exception\FileNotFoundException;
  */
 class MediaExportStep extends AbstractStep
 {
-    /** @var string */
+    /** @var ExportLocation */
     protected $exportLocation;
 
     /** @var string */

--- a/Step/MediaExportStep.php
+++ b/Step/MediaExportStep.php
@@ -6,6 +6,7 @@ use Akeneo\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\AbstractStep;
 use Akeneo\Component\FileStorage\Exception\FileTransferException;
+use Snowio\Bundle\MediaExport\ExportLocation;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 
@@ -34,7 +35,7 @@ class MediaExportStep extends AbstractStep
         $name,
         EventDispatcherInterface $eventDispatcher,
         JobRepositoryInterface $jobRepository,
-        $exportLocation,
+        ExportLocation $exportLocation,
         $logFile
     ) {
         parent::__construct($name, $eventDispatcher, $jobRepository);
@@ -56,7 +57,7 @@ class MediaExportStep extends AbstractStep
     {
         try {
             $currentExportDir = rtrim($stepExecution->getJobParameters()->get('exportDir'), '/');
-            $newExportDir = rtrim($this->exportLocation, '/');
+            $newExportDir = rtrim($this->exportLocation->toString(), '/');
 
             $stepExecution->addSummaryInfo('log_file', $this->logFile);
             $stepExecution->addSummaryInfo('export_location', $newExportDir);


### PR DESCRIPTION
- [x] Use a value object to handle various kinds of export location (local / without user / remote)
- [x] Trying to use symfony di
- [x] defaults on constructors to prevent generation of parameters from blowing up
- [x] ~nullable service arguments ?~ used false instead