### PR TITLE
Add new fields to configure media rsync step per job profile

### DIFF
--- a/Job/JobParameters/ConstraintCollectionProvider/ConstraintTrait.php
+++ b/Job/JobParameters/ConstraintCollectionProvider/ConstraintTrait.php
@@ -39,7 +39,10 @@ trait ConstraintTrait
             'exportDir'     => [
                 new NotBlank(['groups' => ['Default', 'Execution', 'FileConfiguration']]),
                 new WritableDirectory(['groups' => ['Execution', 'FileConfiguration']]),
-            ]
+            ],
+            'rsyncDirectory'     => [],
+            'rsyncUser'     => [],
+            'rsyncHost'     => [],
         ], $simpleFields)]);
     }
 }

--- a/Job/JobParameters/DefaultValuesProvider/DefaultValuesTrait.php
+++ b/Job/JobParameters/DefaultValuesProvider/DefaultValuesTrait.php
@@ -21,6 +21,9 @@ trait DefaultValuesTrait
             'applicationId' => '',
             'secretKey'     => '',
             'exportDir'     => '',
+            'rsyncDirectory'=> '',
+            'rsyncUser'     => '',
+            'rsyncHost'     => '',
         ], $simpleDefaults);
     }
 }

--- a/MediaExport/ExportLocation.php
+++ b/MediaExport/ExportLocation.php
@@ -44,4 +44,25 @@ class ExportLocation
 
         return $this->directory;
     }
+
+    public function setUser($user)
+    {
+        if (is_string($user) && !empty($user)) {
+            $this->user = $user;
+        }
+    }
+
+    public function setDirectory($directory)
+    {
+        if (is_string($directory) && !empty($directory)) {
+            $this->directory = $directory;
+        }
+    }
+
+    public function setHost($host)
+    {
+        if (is_string($host) && !empty($host)) {
+            $this->host = $host;
+        }
+    }
 }

--- a/Resources/config/form_extensions/snowio_product_export_edit.yml
+++ b/Resources/config/form_extensions/snowio_product_export_edit.yml
@@ -180,6 +180,39 @@ extensions:
             label: snowio_connector.form.job_instance.tab.properties.export_dir.title
             tooltip: snowio_connector.form.job_instance.tab.properties.export_dir.help
 
+    snowio-csv-product-export-edit-properties-rsync-directory:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 220
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncDirectory
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.rsync_directory.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_directory.help
+
+    snowio-csv-product-export-edit-properties-rsync-user:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 230
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncUser
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.rsync_user.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_user.help
+
+    snowio-csv-product-export-edit-properties-rsync-host:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 240
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncHost
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.rsync_host.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_host.help
+
     snowio-csv-product-export-edit-label:
         module: pim/job/common/edit/label
         parent: snowio-csv-product-export-edit

--- a/Resources/config/form_extensions/snowio_product_export_show.yml
+++ b/Resources/config/form_extensions/snowio_product_export_show.yml
@@ -169,6 +169,39 @@ extensions:
             label: snowio_connector.form.job_instance.tab.properties.export_dir.title
             tooltip: snowio_connector.form.job_instance.tab.properties.export_dir.help
 
+    snowio-csv-product-export-show-properties-rsync-directory:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 230
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncDirectory
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.rsync_directory.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_directory.help
+
+    snowio-csv-product-export-show-properties-rsync-user:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 240
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncUser
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.rsync_user.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_user.help
+
+    snowio-csv-product-export-show-properties-rsync-host:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 250
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncHost
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.rsync_host.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_host.help
+
     snowio-csv-product-export-show-content-structure:
         module: pim/job/product/edit/content/structure
         parent: snowio-csv-product-export-show-content

--- a/Resources/config/form_extensions/snowio_simple_export_edit.yml
+++ b/Resources/config/form_extensions/snowio_simple_export_edit.yml
@@ -131,6 +131,39 @@ extensions:
             label: snowio_connector.form.job_instance.tab.properties.export_dir.title
             tooltip: snowio_connector.form.job_instance.tab.properties.export_dir.help
 
+    snowio-csv-export-edit-properties-rsync-directory:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 190
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncDirectory
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.rsync_directory.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_directory.help
+
+    snowio-csv-export-edit-properties-rsync-user:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 200
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncUser
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.rsync_user.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_user.help
+
+    snowio-csv-export-edit-properties-rsync-host:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 210
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncHost
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.rsync_host.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_host.help
+
     snowio-csv-export-edit-label:
         module: pim/job/common/edit/label
         parent: snowio-csv-export-edit

--- a/Resources/config/form_extensions/snowio_simple_export_show.yml
+++ b/Resources/config/form_extensions/snowio_simple_export_show.yml
@@ -126,6 +126,39 @@ extensions:
             label: snowio_connector.form.job_instance.tab.properties.export_dir.title
             tooltip: snowio_connector.form.job_instance.tab.properties.export_dir.help
 
+    snowio-csv-export-show-properties-rsync-directory:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 190
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncDirectory
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.rsync_directory.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_directory.help
+
+    snowio-csv-export-show-properties-rsync-user:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 200
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncUser
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.rsync_user.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_user.help
+
+    snowio-csv-export-show-properties-rsync-host:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 210
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncHost
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.rsync_host.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_host.help
+
     snowio-csv-export-show-label:
         module: pim/job/common/edit/label
         parent: snowio-csv-export-show

--- a/Resources/translations/jsmessages.en.yml
+++ b/Resources/translations/jsmessages.en.yml
@@ -19,4 +19,13 @@ snowio_connector.form.job_instance.tab.properties:
   export_dir:
     title: Export Directory
     help: The directory to store CSV and ZIP files.
+  rsync_directory:
+    title: Rsync Directory
+    help: The directory to rsync images to
+  rsync_user:
+    title: Rsync User
+    help: The user for the media rsync step.
+  rsync_host:
+    title: Rsync Host
+    help: The host for the media rsync step.
 

--- a/Step/MediaExportStep.php
+++ b/Step/MediaExportStep.php
@@ -59,6 +59,11 @@ class MediaExportStep extends AbstractStep
     {
         try {
             $currentExportDir = rtrim($stepExecution->getJobParameters()->get('exportDir'), '/');
+
+            $this->exportLocation->setUser($stepExecution->getJobParameters()->get('rsyncUser'));
+            $this->exportLocation->setHost($stepExecution->getJobParameters()->get('rsyncHost'));
+            $this->exportLocation->setDirectory($stepExecution->getJobParameters()->get('rsyncDirectory'));
+
             $newExportDir = rtrim($this->exportLocation->toString(), '/');
 
             $stepExecution->addSummaryInfo('export_location', $newExportDir);


### PR DESCRIPTION
Allows 3 additional configurations on job profiles, for user, host and destination to rsync to. It overrides the yml configuration previously introduced only if set in the job, so this is backwards compatible.